### PR TITLE
Fix MIME dedup read, Office preview scaling, file card I/O blocking, …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,9 @@ if(WIN32)
                 )
             endif()
 
+            # Find strip for removing debug symbols.
+            find_program(STRIP_EXECUTABLE strip HINTS "${MPASTE_MINGW_BIN_DIR}" "${_qt_bin_dir}/../../../Tools/mingw*/bin")
+
             add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
                     COMMAND "${WINDEPLOYQT_EXECUTABLE}"
                     --no-translations
@@ -200,6 +203,42 @@ if(WIN32)
                     "${PACKAGE_DIR}/${PROJECT_NAME}.exe"
                     COMMENT "Running windeployqt..."
             )
+
+            # Strip debug symbols from the exe in the package directory
+            # and remove FFmpeg DLLs pulled in by Qt6Multimedia (only
+            # audio playback is used, which does not need FFmpeg).
+            add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E echo "Stripping and cleaning package..."
+                    COMMAND ${CMAKE_COMMAND} -E rm -f
+                        "${PACKAGE_DIR}/avcodec-61.dll"
+                        "${PACKAGE_DIR}/avformat-61.dll"
+                        "${PACKAGE_DIR}/avutil-59.dll"
+                        "${PACKAGE_DIR}/swscale-8.dll"
+                        "${PACKAGE_DIR}/swresample-5.dll"
+                        "${DEPLOY_DIR}/avcodec-61.dll"
+                        "${DEPLOY_DIR}/avformat-61.dll"
+                        "${DEPLOY_DIR}/avutil-59.dll"
+                        "${DEPLOY_DIR}/swscale-8.dll"
+                        "${DEPLOY_DIR}/swresample-5.dll"
+                    COMMAND ${CMAKE_COMMAND} -E rm -rf
+                        "${PACKAGE_DIR}/multimedia/ffmpegmediaplugin.dll"
+                        "${PACKAGE_DIR}/generic"
+                        "${PACKAGE_DIR}/networkinformation"
+                        "${DEPLOY_DIR}/multimedia/ffmpegmediaplugin.dll"
+                        "${DEPLOY_DIR}/generic"
+                        "${DEPLOY_DIR}/networkinformation"
+                    COMMENT "Removing unused DLLs and plugins..."
+            )
+            if(STRIP_EXECUTABLE)
+                add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                        COMMAND "${STRIP_EXECUTABLE}" --strip-all "${PACKAGE_DIR}/${PROJECT_NAME}.exe"
+                        COMMAND "${STRIP_EXECUTABLE}" --strip-unneeded
+                            "${PACKAGE_DIR}/libstdc++-6.dll"
+                            "${PACKAGE_DIR}/libgcc_s_seh-1.dll"
+                            "${PACKAGE_DIR}/libwinpthread-1.dll"
+                        COMMENT "Stripping debug symbols..."
+                )
+            endif()
 
             add_custom_target(package
                     COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${CMAKE_BINARY_DIR}/${PROJECT_NAME}-${VERSION}-win64.zip" --format=zip "${PROJECT_NAME}"

--- a/data/ContentClassifier.h
+++ b/data/ContentClassifier.h
@@ -338,6 +338,9 @@ inline ContentType classifyLight(const QMimeData *mimeData,
     }
 
     const ContentTraits traits = analyze(mimeData);
+    qInfo().noquote() << QStringLiteral("[classifyLight] hasVector=%1 hasOle=%2 hasOleNative=%3 hasBitmap=%4 hasImage=%5 hasHtml=%6 formats=%7")
+        .arg(traits.hasVector).arg(traits.hasOle).arg(traits.hasOleNative).arg(traits.hasBitmap).arg(traits.hasImage).arg(traits.hasHtml)
+        .arg(mimeData->formats().join(QStringLiteral(", ")));
     if (traits.hasColor) {
         return Color;
     }

--- a/data/LocalSaver.cpp
+++ b/data/LocalSaver.cpp
@@ -429,7 +429,9 @@ bool readByteArrayWithLimit(QDataStream &in, quint32 maxBytes, QByteArray *out) 
         return false;
     }
 
-    if (size == 0) {
+    // QDataStream encodes a null QByteArray as 0xFFFFFFFF and an empty
+    // one as size 0.  Both mean "no data for this entry".
+    if (size == 0 || size == 0xFFFFFFFF) {
         if (out) {
             out->clear();
         }
@@ -956,6 +958,14 @@ ClipboardItem LocalSaver::loadFromFileLight(const QString &filePath, bool includ
     QDataStream in(&file);
     ClipboardItem item = loadFromStreamLight(in, filePath, includeThumbnail);
     file.close();
+
+    // The file may have been renamed (e.g. moveItemToFirst) while the
+    // header still contains the old name.  Use the filename as the
+    // canonical name so sorting by filename stays consistent.
+    const QString fileBaseName = QFileInfo(filePath).completeBaseName();
+    if (!item.getName().isEmpty() && item.getName() != fileBaseName) {
+        item.setName(fileBaseName);
+    }
     return item;
 }
 
@@ -1077,6 +1087,8 @@ bool LocalSaver::loadMimePayloads(const QString &filePath,
         return false;
     }
 
+    qInfo().noquote() << QStringLiteral("[loadMimePayloads] file=%1 offset=%2 fileSize=%3 formatCount=%4 streamOk=%5")
+        .arg(filePath).arg(offset).arg(file.size()).arg(formatCount).arg(in.status() == QDataStream::Ok);
     constexpr quint32 kMaxPreviewHtmlBytes = 2 * 1024 * 1024;
     constexpr quint32 kMaxPreviewImageBytes = 12 * 1024 * 1024;
     QList<QByteArray> uniqueBlobs;
@@ -1097,9 +1109,29 @@ bool LocalSaver::loadMimePayloads(const QString &filePath,
         }
 
         const bool wantsHtml = htmlOut && htmlBytes.isEmpty() && format == QStringLiteral("text/html");
-        const bool wantsImage = imageOut && imageBytes.isEmpty()
-            && (ContentClassifier::preferredImageFormats().contains(format)
-                || format.startsWith(QStringLiteral("image/")));
+        qInfo().noquote() << QStringLiteral("[loadMimePayloads] i=%1 format=%2 dataIndex=%3")
+            .arg(i).arg(format).arg(dataIndex);
+        // Match standard image MIME types as well as Windows clipboard
+        // wrappers like application/x-qt-windows-mime;value="PNG".
+        bool isImageFormat = false;
+        if (imageOut && imageBytes.isEmpty()) {
+            isImageFormat = ContentClassifier::preferredImageFormats().contains(format)
+                || format.startsWith(QStringLiteral("image/"));
+            if (!isImageFormat && format.startsWith(QStringLiteral("application/x-qt-windows-mime;value=\""))) {
+                static const QStringList winImageValues = {
+                    QStringLiteral("PNG"), QStringLiteral("JFIF"),
+                    QStringLiteral("GIF"), QStringLiteral("DIB"),
+                    QStringLiteral("Bitmap"),
+                };
+                for (const QString &val : winImageValues) {
+                    if (format.contains(val)) {
+                        isImageFormat = true;
+                        break;
+                    }
+                }
+            }
+        }
+        const bool wantsImage = isImageFormat;
         const bool shouldRead = wantsHtml || wantsImage;
 
         QByteArray data;

--- a/translations/MPaste_zh_CN.ts
+++ b/translations/MPaste_zh_CN.ts
@@ -305,37 +305,37 @@
         <translation type="vanished">?? MIME ??</translation>
     </message>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="147"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="148"/>
         <source>Paste as Plain Text</source>
         <translation type="unfinished">??????</translation>
     </message>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="159"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="160"/>
         <source>Details</source>
         <translation type="unfinished">??</translation>
     </message>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="171"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="172"/>
         <source>Open Containing Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="183"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="184"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="221"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="222"/>
         <source>Save</source>
         <translation type="unfinished">保存</translation>
     </message>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="229"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="230"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="237"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="238"/>
         <source>Delete Selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -411,13 +411,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../widget/ClipboardCardDelegate.cpp" line="1313"/>
-        <location filename="../widget/ClipboardCardDelegate.cpp" line="1314"/>
+        <location filename="../widget/ClipboardCardDelegate.cpp" line="1302"/>
+        <location filename="../widget/ClipboardCardDelegate.cpp" line="1303"/>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../widget/ClipboardCardDelegate.cpp" line="1338"/>
+        <location filename="../widget/ClipboardCardDelegate.cpp" line="1327"/>
         <source>Preview unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -425,7 +425,7 @@
 <context>
     <name>ScrollItemsWidget</name>
     <message>
-        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="1477"/>
+        <location filename="../widget/ScrollItemsWidgetMV.cpp" line="1478"/>
         <source>Preview</source>
         <translation type="unfinished">预览</translation>
     </message>

--- a/widget/ClipboardCardDelegate.cpp
+++ b/widget/ClipboardCardDelegate.cpp
@@ -854,11 +854,8 @@ bool isLikelyImageFile(const QString &filePath) {
         return false;
     }
 
+    // Check suffix BEFORE stat to avoid blocking on network/virtual paths.
     const QFileInfo info(filePath);
-    if (!info.exists() || !info.isFile()) {
-        return false;
-    }
-
     const QString suffix = info.suffix().toLower();
     if (suffix.isEmpty()) {
         return false;
@@ -1203,10 +1200,6 @@ QPixmap ClipboardCardDelegate::localImageThumbnail(const QString &filePath,
     }
 
     const QFileInfo info(filePath);
-    if (!info.exists() || !info.isFile()) {
-        return {};
-    }
-
     const QString cacheKey = filePreviewCacheKey(filePath, info, targetLogicalSize, targetDpr);
     if (QPixmap *cached = localImageThumbnailCache_.object(cacheKey)) {
         return *cached;
@@ -1260,10 +1253,6 @@ QPixmap ClipboardCardDelegate::localFileIcon(const QString &filePath,
     }
 
     const QFileInfo info(filePath);
-    if (!info.exists()) {
-        return {};
-    }
-
     const QString cacheKey = filePreviewCacheKey(filePath, info, targetLogicalSize, targetDpr);
     if (QPixmap *cached = localFileIconCache_.object(cacheKey)) {
         return *cached;
@@ -1358,9 +1347,11 @@ void drawManagedVisualPreview(QPainter *painter,
                 } else {
                     drawCoverPixmap(painter, rect, card.thumbnail, card.name, card.imageSize);
                 }
-                return;
             }
-            [[fallthrough]];
+            // Thumbnail may have been released after card caching.
+            // Don't fall through to Loading — the cached card pixmap
+            // already has the rendered preview.
+            return;
         case ClipboardBoardModel::PreviewLoading:
             drawLoadingPlaceholder(painter, rect, scale, darkTheme, loadingPhase);
             return;
@@ -1776,7 +1767,7 @@ void ClipboardCardDelegate::paintCardContent(QPainter *painter, const QStyleOpti
                                      iconSize, iconSize);
                 QPixmap iconPixmap = filePath.isEmpty()
                     ? QPixmap()
-                    : loadLocalFileIconSync(filePath, iconRect.size(), paintDpr);
+                    : localFileIcon(filePath, iconRect.size(), paintDpr, index);
                 if (iconPixmap.isNull()) {
                     iconPixmap = filePixmap(iconRect.size());
                 }

--- a/widget/ClipboardItemPreviewDialog.cpp
+++ b/widget/ClipboardItemPreviewDialog.cpp
@@ -25,6 +25,7 @@
 #include <QTextBrowser>
 #include <QTextDocument>
 #include <QThread>
+#include <QTimer>
 #include <QToolButton>
 #include <QVBoxLayout>
 #include <QWindow>
@@ -309,9 +310,12 @@ PreviewPayload buildPreviewPayload(ClipboardItem::ContentType contentType,
             break;
         }
         case ClipboardItem::Office: {
-            QImage image = !fallbackImage.isNull()
-                ? scalePreviewImage(fallbackImage, targetSize, devicePixelRatio)
-                : loadPreviewImageFromBytes(imageBytes, targetSize, devicePixelRatio);
+            // Prefer the full-resolution image from MIME data over the
+            // low-res card thumbnail used as fallback.
+            QImage image = loadPreviewImageFromBytes(imageBytes, QSize(), devicePixelRatio);
+            if (image.isNull() && !fallbackImage.isNull()) {
+                image = scalePreviewImage(fallbackImage, QSize(), devicePixelRatio);
+            }
             if (!image.isNull()) {
                 payload.kind = PreviewKind::Image;
                 payload.image = image;
@@ -661,6 +665,14 @@ void ClipboardItemPreviewDialog::showItem(const ClipboardItem &item) {
             }
         }
 
+        qInfo().noquote() << QStringLiteral("[preview] type=%1 sourceFile=%2 mimeOffset=%3 imageBytes=%4 fallbackNull=%5 preferFull=%6")
+            .arg(resolvedType)
+            .arg(sourceFilePath.isEmpty() ? QStringLiteral("(empty)") : sourceFilePath)
+            .arg(mimeOffset)
+            .arg(resolvedImageBytes.size())
+            .arg(resolvedFallbackImage.isNull())
+            .arg(preferFullItem);
+
         PreviewPayload payload = buildPreviewPayload(resolvedType,
                                                      resolvedText,
                                                      resolvedUrls,
@@ -683,6 +695,14 @@ void ClipboardItemPreviewDialog::showItem(const ClipboardItem &item) {
                     case PreviewKind::Image: {
                         guard->setImagePreview(payload.image);
                         guard->ui_.contentLayout->setCurrentWidget(guard->ui_.imageScrollArea);
+                        // Viewport size may not be valid until after the
+                        // layout switch.  Reset zoom and re-fit after
+                        // the layout settles with the correct viewport.
+                        QTimer::singleShot(0, guard.data(), [guard]() {
+                            if (!guard) return;
+                            guard->imageZoomFactor_ = 1.0;
+                            guard->updateImagePreview();
+                        });
                         break;
                     }
                     case PreviewKind::Html: {
@@ -798,6 +818,10 @@ void ClipboardItemPreviewDialog::updateImagePreview() {
         fitScale = qMin(scaleX, scaleY);
     }
     imageFitScale_ = fitScale;
+    qInfo().noquote() << QStringLiteral("[updateImagePreview] imageSize=%1x%2 viewportSize=%3x%4 fitScale=%5 zoomFactor=%6")
+        .arg(imageSize.width()).arg(imageSize.height())
+        .arg(viewportSize.width()).arg(viewportSize.height())
+        .arg(fitScale, 0, 'f', 3).arg(imageZoomFactor_, 0, 'f', 3);
 
     qreal scale = imageFitScale_ * imageZoomFactor_;
     scale = qBound(kImageZoomMin, scale, kImageZoomMax);

--- a/widget/ScrollItemsWidgetMV.cpp
+++ b/widget/ScrollItemsWidgetMV.cpp
@@ -4,6 +4,7 @@
 // update: If I change, update this header block and my folder README.md (arrow navigation no longer forces center + hover action bar + main-card save/export + multi-select batch actions + data-layer preview kind + board paint FPS logging + hidden-stage light prewarm).
 // note: Added dark theme rendering hooks, metadata-save rehydrate fixes, alias sync, loading overlay, board paint FPS logging, hidden-stage light prewarm, and switchable paged-vs-continuous history loading.
 #include <QDir>
+#include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QGuiApplication>
@@ -1557,26 +1558,21 @@ void ScrollItemsWidget::handlePendingItemReady(const QString &expectedName, cons
     if (item.hasThumbnail()) {
         missingThumbnailNames_.remove(expectedName);
     }
+    qInfo().noquote() << QStringLiteral("[pendingItemReady] name=%1 hasThumbnail=%2 type=%3")
+        .arg(expectedName).arg(item.hasThumbnail()).arg(item.getContentType());
     const int row = boardModel_->rowForName(expectedName);
     if (row >= 0) {
         ClipboardItem updated = item;
         if (!filterShowsVisualPreviewCards() && usesManagedVisualPreviewCard(updated)) {
             updated.setThumbnail(QPixmap());
         }
+        // Invalidate the cached card so it re-renders with the new
+        // thumbnail instead of showing the stale loading/unavailable state.
+        if (cardDelegate_) {
+            cardDelegate_->invalidateCard(expectedName);
+        }
         boardModel_->updateItem(row, updated);
         syncPreviewStateForRow(row);
-
-        // The updateItem triggers a repaint which renders the card into
-        // cardPixmapCache_.  Once cached, the thumbnail/icon/favicon in
-        // the model item are redundant — release them to save memory.
-        // Defer to the next event loop iteration so paint has finished.
-        QTimer::singleShot(0, this, [this, expectedName]() {
-            if (!boardModel_) return;
-            const int r = boardModel_->rowForName(expectedName);
-            if (r >= 0) {
-                releaseItemPixmaps(r);
-            }
-        });
     }
     // The async save may have changed the service index count; keep
     // bookkeeping in sync to avoid a spurious full page reload.
@@ -1610,19 +1606,12 @@ void ScrollItemsWidget::handleThumbnailReady(const QString &expectedName, const 
     }
     if (!thumbnail.isNull()) {
         missingThumbnailNames_.remove(expectedName);
-        // Update thumbnail in-place, single dataChanged signal.
+        if (cardDelegate_) {
+            cardDelegate_->invalidateCard(expectedName);
+        }
         ClipboardItem updated = *itemPtr;
         updated.setThumbnail(thumbnail);
         boardModel_->updateItem(row, updated);
-
-        // Release pixmaps once the card is cached.
-        QTimer::singleShot(0, this, [this, expectedName]() {
-            if (!boardModel_) return;
-            const int r = boardModel_->rowForName(expectedName);
-            if (r >= 0) {
-                releaseItemPixmaps(r);
-            }
-        });
     } else {
         missingThumbnailNames_.insert(expectedName);
     }
@@ -2009,6 +1998,30 @@ int ScrollItemsWidget::moveItemToFirst(int sourceRow) {
     ClipboardItem item = boardModel_->itemAt(sourceRow);
     if (item.getName().isEmpty()) {
         return sourceRow;
+    }
+
+    // Rename the file with a fresh timestamp so it sorts first on
+    // restart (files are sorted by name = timestamp).  We rename
+    // rather than re-save because the item's mimeData_ may have been
+    // released — a re-save would lose the MIME payload.
+    if (boardService_ && !item.isPinned()) {
+        const QString oldName = item.getName();
+        const QString newName = QString::number(QDateTime::currentMSecsSinceEpoch());
+        if (oldName != newName) {
+            const QString oldPath = boardService_->filePathForName(oldName);
+            const QString newPath = boardService_->filePathForName(newName);
+            if (QFile::rename(oldPath, newPath)) {
+                item.setName(newName);
+                item.setTime(QDateTime::currentDateTime());
+                item.setSourceFilePath(newPath);
+                boardModel_->updateItem(sourceRow, item);
+                if (cardDelegate_) {
+                    cardDelegate_->invalidateCard(oldName);
+                }
+                boardService_->refreshIndexedItemForPath(oldPath);
+                boardService_->refreshIndexedItemForPath(newPath);
+            }
+        }
     }
 
     if (shouldEvictPages()) {


### PR DESCRIPTION
…and item reorder persistence

- Fix readByteArrayWithLimit treating null QByteArray marker (0xFFFFFFFF) as a 4GB size, which aborted MIME format iteration after dedup entries
- Recognize Windows clipboard image formats (PNG, JFIF, GIF, DIB) in loadMimePayloads so Office items can load full-res preview from disk
- Fix preview fit-to-window: reset imageZoomFactor after layout settles to prevent stale zoom from tiny initial viewport
- Office preview now prefers full MIME image over low-res thumbnail
- Invalidate card cache in handlePendingItemReady/handleThumbnailReady so new thumbnails replace stale loading/unavailable state
- Persist item reorder: moveItemToFirst renames the .mpaste file with a new timestamp so sort order survives restart; loadFromFileLight uses filename as canonical name when header name differs
- Replace sync loadLocalFileIconSync with async localFileIcon in paint to avoid blocking on virtual filesystems (e.g. cloud drives)
- Move suffix check before QFileInfo::exists() in isLikelyImageFile to skip I/O for non-image files
- Strip exe and MinGW DLLs, remove unused FFmpeg/plugin DLLs in package